### PR TITLE
Removes unneeded require in local tests

### DIFF
--- a/conf/local.conf.js
+++ b/conf/local.conf.js
@@ -1,5 +1,3 @@
-var browserstack = require('browserstack-local');
-
 nightwatch_config = {
   src_folders : [ "tests/local" ],
 

--- a/conf/parallel_local.conf.js
+++ b/conf/parallel_local.conf.js
@@ -1,5 +1,3 @@
-var browserstack = require('browserstack-local');
-
 nightwatch_config = {
   src_folders : [ "tests/local" ],
 


### PR DESCRIPTION
Please correct me if I'm wrong, but I don't think the local tests are using the browserstack-local import/require at the top. I was able to run both local and parallel_local without them, so this PR is to remove them. 
Two reasons for this:
First, as example code, it is a bit confusing to those learning this (me).
Second, anyone using eslint will get a ['no-unused-vars'](http://eslint.org/docs/rules/no-unused-vars) error.