### PR TITLE
fix(security): bump braces to 3.0.3 — ReDoS (SDK-6068)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -203,11 +203,11 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browser-process-hrtime": {
@@ -623,9 +623,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "requires": {
         "to-regex-range": "^5.0.1"
       }


### PR DESCRIPTION
## Summary
Remediates **[SDK-6068](https://browserstack.atlassian.net/browse/SDK-6068)** — `braces` ReDoS (**GHSA-grv7-fg5c-xmjg**, CWE-400, CVSS 6.5).

`braces@3.0.2` (< 3.0.3) is vulnerable to uncontrolled resource consumption: a malformed brace expression triggers catastrophic backtracking that hangs the process. It's reachable transitively here (`nightwatch → chokidar → braces`) and is used during nightwatch test-path glob expansion. In CI, if an attacker can influence the test path (chains with the `commit_sha` vector), the runner can be hung — pipeline DoS.

## Change (lockfile-only, surgical)
The lockfile is `lockfileVersion: 1`; rather than migrate the whole file to v3, this is a targeted 2-entry edit:
- `braces` 3.0.2 → **3.0.3** (its `requires` floor moves to `fill-range ^7.1.1`)
- `fill-range` 7.0.1 → **7.1.1** (braces 3.0.3's pinned dependency; `to-regex-range ^5.0.1` dep unchanged; braces is its only consumer)

Patch-level bump, non-breaking, no `package.json` change needed.

## Verification
- `npm ci` against the edited lockfile **succeeds** (proves the lockfile is internally consistent).
- `npm ls braces` resolves **braces@3.0.3** / fill-range@7.1.1 — vulnerable `braces@3.0.2` is **gone**.
- Diff: `package-lock.json` only, 7 ins / 7 del.

Jira: SDK-6068

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-6068]: https://browserstack.atlassian.net/browse/SDK-6068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ