### PR TITLE
fix(security): CI hardening — permissions, npm ci, Dependabot, CODEOWNERS (SDK-6067/6069/6071)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-.github/* @browserstack/asi-devs
+.github/** @browserstack/asi-devs
 
 * @browserstack/automate-public-repos

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
-.github/** @browserstack/asi-devs
-
+# CODEOWNERS uses last-match-wins precedence, so least-specific rules must come
+# first. The broad catch-all is listed before the .github/** rule so that the
+# latter is the *last* (winning) match for workflow/config files (SDK-6071).
 * @browserstack/automate-public-repos
+
+.github/** @browserstack/asi-devs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Dependabot configuration (SDK-6069) — keeps npm dependencies patched and
+# surfaces transitive CVEs (e.g. the braces ReDoS) automatically going forward.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "master"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -12,8 +13,13 @@ updates:
       - "security"
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "master"
     schedule:
       interval: "weekly"
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/reviewing_changes.yml
+++ b/.github/workflows/reviewing_changes.yml
@@ -3,6 +3,12 @@
 
 name: NodeJS Test workflow on workflow_dispatch
 
+# Least-privilege default token scopes (SDK-6067). The job only needs to read
+# the repo (checkout) and write check runs via github-script.
+permissions:
+  contents: read
+  checks: write
+
 on:
   workflow_dispatch:
     inputs:
@@ -53,7 +59,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run sample tests
         run: npm run sample-test


### PR DESCRIPTION
## Summary
Batched, mechanical CI/config hardening for three tickets (same repo, same type).

| Ticket | CWE | Change |
|--------|-----|--------|
| [SDK-6067](https://browserstack.atlassian.net/browse/SDK-6067) | 732 | Add least-privilege top-level `permissions:` to `reviewing_changes.yml` |
| [SDK-6069](https://browserstack.atlassian.net/browse/SDK-6069) | 1357 | Add `.github/dependabot.yml` + switch `npm install` → `npm ci` |
| [SDK-6071](https://browserstack.atlassian.net/browse/SDK-6071) | 284 | Widen CODEOWNERS `.github/*` → `.github/**` |

## Details
**SDK-6067 — workflow token scopes.** The workflow had no `permissions:` block, so it inherited broad default `GITHUB_TOKEN` scopes. The job only checks out the repo and creates check runs via `actions/github-script`, so it's scoped to exactly:
```yaml
permissions:
  contents: read
  checks: write
```

**SDK-6069 — dependency drift.** Adds `.github/dependabot.yml` with weekly **npm** and **github-actions** update schedules (the latter also helps the unpinned-actions risks tracked elsewhere in this audit), and switches the install step to `npm ci` for reproducible, lockfile-pinned installs.

**SDK-6071 — CODEOWNERS gap.** `.github/*` is a single-level glob that does **not** match `.github/workflows/*`, leaving workflow files without required Code Owner review. Widened to `.github/**`.

## Verification
- Both YAML files parse (js-yaml); workflow `permissions` resolves to `{contents: read, checks: write}`.
- `npm ci` succeeds against the committed lockfile — the `npm install` → `npm ci` switch will **not** break CI.
- Diff scoped to `.github/` only (CODEOWNERS, reviewing_changes.yml, new dependabot.yml).

> Note: `permissions` and `npm ci` only take effect once merged to the default branch and the workflow is next dispatched.

Jira: SDK-6067, SDK-6069, SDK-6071

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-6067]: https://browserstack.atlassian.net/browse/SDK-6067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-6069]: https://browserstack.atlassian.net/browse/SDK-6069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-6071]: https://browserstack.atlassian.net/browse/SDK-6071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ