### PR TITLE
fix(security): nightwatch.conf.js — env-var creds + own-keys merge (SDK-6070/6072)

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -11,8 +11,8 @@ const bstackOptions = {
     "sessionName" : "BStack nightwatch snippet",
     "source": "nightwatch:sample-sdk:v1.0",
     "seleniumVersion" : "4.0.0",
-    userName: '${BROWSERSTACK_USERNAME}' || 'YOUR_USERNAME',
-    accessKey: '${BROWSERSTACK_ACCESS_KEY}' || 'YOUR_ACCESS_KEY',
+    userName: process.env.BROWSERSTACK_USERNAME || 'YOUR_USERNAME',
+    accessKey: process.env.BROWSERSTACK_ACCESS_KEY || 'YOUR_ACCESS_KEY',
   },
 }
 
@@ -78,7 +78,7 @@ const nightwatchConfigs = {
   }
 }
 
-for(let key in additonalEnvironments.test_settings) {
+for (const key of Object.keys(additonalEnvironments.test_settings)) {
   nightwatchConfigs.test_settings[key] = {
     ...browserStack,
     ...additonalEnvironments.test_settings[key]


### PR DESCRIPTION
## ⚠️ Logic-vuln changes — please human-review the behavioral impact
Two source-level security fixes in `nightwatch.conf.js`. Unlike the dependency/CI PRs in this audit, these change runtime behavior, so they're flagged for human review.

| Ticket | CWE | Fix |
|--------|-----|-----|
| [SDK-6070](https://browserstack.atlassian.net/browse/SDK-6070) | 321 | Read credentials from `process.env` instead of non-interpolating string literals |
| [SDK-6072](https://browserstack.atlassian.net/browse/SDK-6072) | 915 | Iterate own keys only (`Object.keys`) instead of prototype-walking `for..in` |

### SDK-6070 — credentials as JS literals
```diff
- userName: '${BROWSERSTACK_USERNAME}' || 'YOUR_USERNAME',
- accessKey: '${BROWSERSTACK_ACCESS_KEY}' || 'YOUR_ACCESS_KEY',
+ userName: process.env.BROWSERSTACK_USERNAME || 'YOUR_USERNAME',
+ accessKey: process.env.BROWSERSTACK_ACCESS_KEY || 'YOUR_ACCESS_KEY',
```
The single-quoted `'${BROWSERSTACK_USERNAME}'` does **not** interpolate — it's a literal string, always truthy, so the env var was never read and the `|| 'YOUR_...'` fallback was dead code. **Behavioral change to confirm:** the sample now actually reads `BROWSERSTACK_USERNAME` / `BROWSERSTACK_ACCESS_KEY` from the environment (falling back to the placeholder when unset), which is the intended behavior.

### SDK-6072 — prototype-chain merge
```diff
- for(let key in additonalEnvironments.test_settings) {
+ for (const key of Object.keys(additonalEnvironments.test_settings)) {
```
`for..in` enumerates inherited (prototype-chain) properties; if `test_settings`'s prototype is polluted, attacker-controlled keys get merged into the nightwatch config. `Object.keys()` restricts to own enumerable properties. Functionally identical for plain objects.

## Verification
- `node --check nightwatch.conf.js` passes.
- `require('./nightwatch.conf.js')` loads cleanly; `test_settings` resolves the same 8 environment keys (default, browserstack, browserstack.chrome/firefox/edge, env1/2/3).
- `userName`/`accessKey` fall back to placeholders when env vars are unset.
- Diff: `nightwatch.conf.js` only, 3 ins / 3 del.

Jira: SDK-6070, SDK-6072

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SDK-6070]: https://browserstack.atlassian.net/browse/SDK-6070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-6072]: https://browserstack.atlassian.net/browse/SDK-6072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ